### PR TITLE
Bug fix from typo

### DIFF
--- a/RunConfiguration/ParallelSequence.cs
+++ b/RunConfiguration/ParallelSequence.cs
@@ -49,7 +49,7 @@ namespace IS4U.RunConfiguration
             {
                 runProfile = Action;
             }
-            int delay = ConfigParameters.DelayInParallelSequence * 1000;
+            int delay = configParameters.DelayInParallelSequence * 1000;
             List<Thread> threads = new List<Thread>();
 
             if (sequences.ContainsKey(Name))


### PR DESCRIPTION
Small typo that made the ParallelSequence crash when its Run function was called.